### PR TITLE
#165763029 Fix validation errors

### DIFF
--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -5,6 +5,7 @@
 #  id         :integer          not null, primary key
 #  body       :string
 #  created_by :string
+#  tags       :text
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,7 +17,7 @@ class User < ApplicationRecord
   has_many :tweets, foreign_key: :created_by
   # Validations
   validates_presence_of :name, :email, :password_digest
-  validates :email,
+  validates :email, uniqueness: {message: "already registered"},
             format: { with: URI::MailTo::EMAIL_REGEXP, message: 'is invalid' }
   validates_format_of :email,
                       with: /((?!\.)[a-z0-9._%+-]+(?!\.)\w)@andela\.com/,

--- a/app/serializers/tweet_serializer.rb
+++ b/app/serializers/tweet_serializer.rb
@@ -5,6 +5,7 @@
 #  id         :integer          not null, primary key
 #  body       :string
 #  created_by :string
+#  tags       :text
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,7 +13,7 @@
 ActiveRecord::Schema.define(version: 20190506114749) do
 
   # These are extensions that must be enabled in order to support this database
-  enable_extension 'plpgsql'
+  enable_extension "plpgsql"
 
   create_table "tweets", force: :cascade do |t|
     t.string   "body"
@@ -23,11 +23,12 @@ ActiveRecord::Schema.define(version: 20190506114749) do
     t.text     "tags"
   end
 
-  create_table 'users', force: :cascade do |t|
-    t.string   'name'
-    t.string   'email'
-    t.string   'password_digest'
-    t.datetime 'created_at',      null: false
-    t.datetime 'updated_at',      null: false
+  create_table "users", force: :cascade do |t|
+    t.string   "name"
+    t.string   "email"
+    t.string   "password_digest"
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
   end
+
 end

--- a/spec/factories/tweets.rb
+++ b/spec/factories/tweets.rb
@@ -5,6 +5,7 @@
 #  id         :integer          not null, primary key
 #  body       :string
 #  created_by :string
+#  tags       :text
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -14,6 +14,6 @@ FactoryBot.define do
   factory :user do
     name { Faker::Name.name }
     email { 'foo.name@andela.com' }
-    password { 'foobar' }
+    password { 'foobar8889583539845' }
   end
 end

--- a/spec/models/tweet_spec.rb
+++ b/spec/models/tweet_spec.rb
@@ -5,6 +5,7 @@
 #  id         :integer          not null, primary key
 #  body       :string
 #  created_by :string
+#  tags       :text
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe 'Users API', type: :request do
 
       it 'returns failure message' do
         expect(json['message'])
-          .to match(/Validation failed: Password can't be blank, Name can't be blank, Email can't be blank, Email is invalid, Email should be of andelan domain, Password digest can't be blank/)
-      end
+          .to match(/Validation failed: Password can't be blank, Name can't be blank, Email can't be blank, Email is invalid, Email should be of andelan domain, Password digest can't be blank/)    
+        end
     end
   end
 end

--- a/spec/serializers/tweet_serializer_spec.rb
+++ b/spec/serializers/tweet_serializer_spec.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: tweets
+#
+#  id         :integer          not null, primary key
+#  body       :string
+#  created_by :string
+#  tags       :text
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
 require 'rails_helper'
 
 RSpec.describe TweetSerializer, type: :serializer do


### PR DESCRIPTION
#### What does this PR do?
- enables  a user to only signup once, no duplicate users allowed
- Separates validation messages
#### Description of Task to be completed?
-add validation to ensure a user I can only signup once, no duplicate users allowed
- add validation to ensure separate validation messages
#### How should this be manually tested?
- check out `bg-fix-validation-errors-165763029` branch
- try to sign up with a password with less than 8 characters, there should be an error message
- try to sign up the same email more than once. there should be an error
#### Any background context you want to provide?
N/A
#### What are the relevant PT Stories?
[#165763029](https://www.pivotaltracker.com/story/show/165763029)
#### Screenshots (if appropriate)
N/A
#### Questions:
N/A
