### PR TITLE
Fix Username for TweetAuthor

### DIFF
--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -2,7 +2,7 @@
 #
 # Table name: tweets
 #
-#  id         :integer          not null, primary key
+#  id         :bigint(8)        not null, primary key
 #  body       :string
 #  created_by :string
 #  tags       :text

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@
 #
 # Table name: users
 #
-#  id              :integer          not null, primary key
+#  id              :bigint(8)        not null, primary key
 #  email           :string
 #  name            :string
 #  password_digest :string

--- a/app/serializers/tweet_serializer.rb
+++ b/app/serializers/tweet_serializer.rb
@@ -2,7 +2,7 @@
 #
 # Table name: tweets
 #
-#  id         :integer          not null, primary key
+#  id         :bigint(8)        not null, primary key
 #  body       :string
 #  created_by :string
 #  tags       :text
@@ -24,9 +24,9 @@ class TweetSerializer < ActiveModel::Serializer
   end
 
   def curr_user
-    curr_user = User.select(:name).where(
-      id: object.created_by.first
-        ).pluck(:name)[0]
+    curr_user = User.select(:name, :id).where(
+      id: object.created_by
+      ).pluck(:name)[0]
     curr_user
   end
 end

--- a/db/migrate/20190517095351_change_integer_limit_in_users.rb
+++ b/db/migrate/20190517095351_change_integer_limit_in_users.rb
@@ -1,0 +1,6 @@
+class ChangeIntegerLimitInUsers < ActiveRecord::Migration[5.0]
+    def change
+      change_column :users, :id, :integer, limit: 8
+    end
+  end
+  

--- a/db/migrate/20190517114649_change_integer_limit_in_tweets.rb
+++ b/db/migrate/20190517114649_change_integer_limit_in_tweets.rb
@@ -1,0 +1,5 @@
+class ChangeIntegerLimitInTweets < ActiveRecord::Migration[5.0]
+    def change
+      change_column :tweets, :id, :integer, limit: 8
+    end
+  end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190506114749) do
+ActiveRecord::Schema.define(version: 20190517114649) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "tweets", force: :cascade do |t|
+  create_table "tweets", id: :bigserial, force: :cascade do |t|
     t.string   "body"
     t.string   "created_by"
     t.datetime "created_at", null: false
@@ -23,7 +23,7 @@ ActiveRecord::Schema.define(version: 20190506114749) do
     t.text     "tags"
   end
 
-  create_table "users", force: :cascade do |t|
+  create_table "users", id: :bigserial, force: :cascade do |t|
     t.string   "name"
     t.string   "email"
     t.string   "password_digest"

--- a/spec/factories/tweets.rb
+++ b/spec/factories/tweets.rb
@@ -2,7 +2,7 @@
 #
 # Table name: tweets
 #
-#  id         :integer          not null, primary key
+#  id         :bigint(8)        not null, primary key
 #  body       :string
 #  created_by :string
 #  tags       :text

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,7 +2,7 @@
 #
 # Table name: users
 #
-#  id              :integer          not null, primary key
+#  id              :bigint(8)        not null, primary key
 #  email           :string
 #  name            :string
 #  password_digest :string

--- a/spec/models/tweet_spec.rb
+++ b/spec/models/tweet_spec.rb
@@ -2,7 +2,7 @@
 #
 # Table name: tweets
 #
-#  id         :integer          not null, primary key
+#  id         :bigint(8)        not null, primary key
 #  body       :string
 #  created_by :string
 #  tags       :text

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,7 +2,7 @@
 #
 # Table name: users
 #
-#  id              :integer          not null, primary key
+#  id              :bigint(8)        not null, primary key
 #  email           :string
 #  name            :string
 #  password_digest :string

--- a/spec/serializers/tweet_serializer_spec.rb
+++ b/spec/serializers/tweet_serializer_spec.rb
@@ -2,7 +2,7 @@
 #
 # Table name: tweets
 #
-#  id         :integer          not null, primary key
+#  id         :bigint(8)        not null, primary key
 #  body       :string
 #  created_by :string
 #  tags       :text


### PR DESCRIPTION
#### What does this PR do?
fixes username display for a tweet author
#### Description of Task to be completed?
- render the correct username for the author who posted a tweet
#### How should this be manually tested?
- Check out `bg-fix-rendering-of-tweet-authors`
- Login or signup with andela email
- Post a tweet and your username should appear 
#### Any background context you want to provide?
N/A
#### What are the relevant PT Stories?
N/A
#### Screenshots (if appropriate)
N/A
#### Questions:
N/A
